### PR TITLE
make: initial support for meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,22 @@
+project('opensea-operations', 'c', license: 'MPL-2.0', version: '2.0.2')
+
+if get_option('debug')
+  add_project_arguments('-D_DEBUG', language : 'c')
+endif
+
+global_cpp_args = []
+
+if target_machine.system() == 'windows'
+  global_cpp_args += ['-DSTATIC_OPENSEA_OPERATIONS']
+endif
+
+incdir = include_directories('include')
+
+opensea_common = subproject('opensea-common')
+opensea_common_dep = opensea_common.get_variable('opensea_common_dep')
+
+opensea_transport = subproject('opensea-transport')
+opensea_transport_dep = opensea_transport.get_variable('opensea_transport_dep')
+
+opensea_operations_lib = static_library('opensea-operations', 'src/ata_Security.c', 'src/buffer_test.c', 'src/defect.c', 'src/depopulate.c', 'src/device_statistics.c', 'src/drive_info.c', 'src/dst.c', 'src/firmware_download.c', 'src/format.c', 'src/generic_tests.c', 'src/host_erase.c', 'src/logs.c', 'src/nvme_operations.c', 'src/operations.c', 'src/power_control.c', 'src/reservations.c', 'src/sanitize.c', 'src/sas_phy.c', 'src/seagate_operations.c', 'src/sector_repair.c', 'src/set_max_lba.c', 'src/smart.c', 'src/trim_unmap.c', 'src/writesame.c', 'src/zoned_operations.c', c_args : global_cpp_args, dependencies : [opensea_common_dep, opensea_transport_dep], include_directories : incdir)
+opensea_operations_dep = declare_dependency(link_with : opensea_operations_lib, compile_args : global_cpp_args, include_directories : incdir)


### PR DESCRIPTION
The meson build system is a build system with many advantages over others, and one I consider to be the best. It is one of the fastest build systems, has an easy to understand, and extensible syntax (for example a target can be defined to automatically build docs). It supports all platforms the other build systems do (Linux, Windows, FreeBSD) and is easy to use when cross compiling via a cross file (such as with MinGW). It can also programmatically generate the version, instead of needing to edit a header file every time. Compiling openSeaChest on my Linux system, meson (configure) took 0.65s and ninja (build) took 16.62s, while the make-based build system took 30.22s.
See https://mesonbuild.com/Overview.html and https://mesonbuild.com/Comparisons.html for more info on the meson build system.
Note: existing build systems can still be used.

[Seagate/openSeaChest#2]

Merge AFTER Seagate/opensea-common#3 and Seagate/opensea-transport#8