### PR TITLE
quick: fix ata smart status overwritten by unknown

### DIFF
--- a/src/drive_info.c
+++ b/src/drive_info.c
@@ -2264,10 +2264,6 @@ int get_ATA_Drive_Information(tDevice *device, ptrDriveInformationSAS_SATA drive
             break;
         }
     }
-    else
-    {
-        driveInfo->smartStatus = 2;
-    }
     if (is_Seagate_Family(device) == SEAGATE)
     {
         driveInfo->lowCurrentSpinupValid = true;


### PR DESCRIPTION
I have one Exos X18 SATA drive connecting to onboard (PCH) SATA. When executing `openSeaChest_xxx -i` it shows SMART status as `Unknown or Not Supported`.

In [drive_info.c line 2043](https://github.com/Seagate/opensea-operations/blob/6d3e7c93f9d638e1915de35d79d0a4173ec55d55/src/drive_info.c#L2043), I could see `smartStatusFromSCTStatusLog` and `driveInfo->smartStatus` are assigned with correct value, but are overwritten in those lines I removed in this commit.

Could you please check whether this fix makes sense?

Signed-off-by: ThunderEX <thunderex@gmail.com>