### PR TITLE
quick: fix date of manufacture on SAS

### DIFF
--- a/src/drive_info.c
+++ b/src/drive_info.c
@@ -3519,9 +3519,11 @@ int get_SCSI_Drive_Information(tDevice* device, ptrDriveInformationSAS_SATA driv
                             if (M_BytesTo2ByteValue(startStopCounterLog[4], startStopCounterLog[5]) == 0x0001)
                             {
                                 //DOM found
+                                char domWeekStr[3] = { startStopCounterLog[12], startStopCounterLog[13], 0 };
+                                char domYearStr[5] = { startStopCounterLog[8], startStopCounterLog[9], startStopCounterLog[10], startStopCounterLog[11], 0 };
                                 driveInfo->dateOfManufactureValid = true;
-                                driveInfo->manufactureYear = M_BytesTo4ByteValue(startStopCounterLog[8], startStopCounterLog[9], startStopCounterLog[10], startStopCounterLog[11]);
-                                driveInfo->manufactureWeek = M_BytesTo2ByteValue(startStopCounterLog[12], startStopCounterLog[13]);
+                                driveInfo->manufactureWeek = C_CAST(uint8_t, strtol(domWeekStr, NULL, 10));
+                                driveInfo->manufactureYear = C_CAST(uint16_t, strtol(domYearStr, NULL, 10));
                             }
                         }
                     }


### PR DESCRIPTION
On SAS, date of manufacture are plain ASCII characters:

```
        0  1  2  3  4  5  6  7  8  9  A  B  C  D
  0x00 0E 00 00 34 00 01 01 06 32 30 32 31 33 38         ...4....202138
```

The original codes treat them as integers.