### PR TITLE
feat: Finish Change_Model_Number_with_Capacity

### DIFF
--- a/include/drive_info.h
+++ b/include/drive_info.h
@@ -307,59 +307,61 @@ extern "C"
         };
     }driveInformation, *ptrDriveInformation;
 
-	typedef struct _driveCapacityModelLogHeader
-	{
-		uint32_t numberOfCapacityModelDescriptor;
-		uint8_t reserved[4];
-	}driveCapacityModelLogHeader, *ptrDriveCapacityModelLogHeader;
+    typedef struct _capacityModelDescriptor
+    {
+        uint64_t capacityMaxAddress;
+        char modelNumber[MODEL_NUM_LEN + 1];//Null terminated
+    }capacityModelDescriptor, *ptrDriveCapacityModelDescriptor;
 
-	typedef struct _driveCapacityModelLogDescriptor
-	{
-		uint64_t driveStatics;
-		char modelNumber[MODEL_NUM_LEN];
-	}driveCapacityModelLogDescriptor, *ptrDriveCapacityModelDescriptor;
+    typedef struct _capacityModelNumberMapping
+    {
+        uint32_t numberOfDescriptors;
+        capacityModelDescriptor descriptor[1];//NOTE: This must be allocated based on how many descriptors are actually available! ex: malloc(sizeof(capacityModelNumberMapping) + (get_capacityModelDescriptor_Count() * sizeof(capacityModelDescriptor)));
+    }capacityModelNumberMapping, *ptrcapacityModelNumberMapping;
 
+    //-----------------------------------------------------------------------------
+    //
+    //  is_Change_Identify_String_Supported(tDevice *device)
+    //
+    //! \brief   Description:  Checks if the device supports Change ID Strings.
+    //
+    //  Entry:
+    //!   \param[in] device = file descriptor
+    //!
+    //  Exit:
+    //!   \return true = changing sector size supported, false = not supported
+    //
+    //-----------------------------------------------------------------------------
+    OPENSEA_OPERATIONS_API bool is_Change_Identify_String_Supported(tDevice *device);
 
+    //-----------------------------------------------------------------------------
+    //
+    //  get_Capacity_Model_Number_Mapping(tDevice* device)
+    //
+    //! \brief   Description:  This function fills in Capacity/Product Mapping
+    //
+    //  Entry:
+    //!   \param[in] device = file descriptor
+    //!
+    //  Exit:
+    //!   \return SUCCESS = pointer to the struct to fill in with Capacity/Product Mapping, FAILURE = NULL.
+    //
+    //-----------------------------------------------------------------------------
+    OPENSEA_OPERATIONS_API ptrcapacityModelNumberMapping get_Capacity_Model_Number_Mapping(tDevice* device);
 
-	typedef struct _driveCapacityProductInformation
-	{
-		driveCapacityModelLogHeader headerInfo;
-		driveCapacityModelLogDescriptor descriptor[10];
-		uint8_t reserved[24];
-	}driveCapacityProductInformation, *ptrDriveCapacityProductInformation;
-
-
-	//-----------------------------------------------------------------------------
-	//
-	//  get_ATA_Capacity_Product_Information(tDevice* device, ptrDriveCapacityProductInformation driveInfo)
-	//
-	//! \brief   Description:  This function fills in Capacity/Product Mapping 
-	//
-	//  Entry:
-	//!   \param[in] device = file descriptor
-	//!   \param driveInformation = pointer to the struct to fill in with Capacity/Product Mapping.
-	//!
-	//  Exit:
-	//!   \return SUCCESS = pass, FAILURE = one of the operations being called inside of this function failed.
-	//
-	//-----------------------------------------------------------------------------
-	OPENSEA_OPERATIONS_API int get_ATA_Capacity_Product_Information(tDevice* device, ptrDriveCapacityProductInformation driveInformation);
-
-	//-----------------------------------------------------------------------------
-	//
-	//  get_ATA_Capacity_Product_Information(tDevice* device, ptrDriveCapacityProductInformation driveInfo)
-	//
-	//! \brief   Description:  This function fills in Capacity/Product Mapping 
-	//
-	//  Entry:
-	//!   \param[in] device = file descriptor
-	//!   \param driveInformation = pointer to the struct to fill in with Capacity/Product Mapping.
-	//!
-	//  Exit:
-	//!   \return SUCCESS = pass, FAILURE = one of the operations being called inside of this function failed.
-	//
-	//-----------------------------------------------------------------------------
-	OPENSEA_OPERATIONS_API int get_SCSI_Capacity_Product_Information(tDevice* device, ptrDriveCapacityProductInformation driveInformation);
+    //-----------------------------------------------------------------------------
+    //
+    //  delete_Capacity_Model_Number_Mapping(ptrcapacityModelNumberMapping capModelMapping)
+    //
+    //! \brief   Description:  This function free allocated Capacity/Product Mapping
+    //
+    //  Entry:
+    //!   \param[in] capModelMapping = pointer to the struct to fill in with Capacity/Product Mapping
+    //!
+    //  Exit:
+    //
+    //-----------------------------------------------------------------------------
+    OPENSEA_OPERATIONS_API void delete_Capacity_Model_Number_Mapping(ptrcapacityModelNumberMapping capModelMapping);
 
     //-----------------------------------------------------------------------------
     //
@@ -478,18 +480,17 @@ extern "C"
 
     //-----------------------------------------------------------------------------
     //
-    //  print_Capacity_Product_Information()
+    //  print_Capacity_Model_Number_Mapping()
     //
     //! \brief   Description:  This function prints capacity Model number mapping information
     //
     //  Entry:
-    //!   \param[in] device = file descriptor
+    //!   \param[in] capModelMapping = pointer to the struct to fill in with Capacity/Product Mapping
     //!
     //  Exit:
-    //!   \return SUCCESS = pass, FAILURE = one of the operations being called inside of this function failed.
     //
     //-----------------------------------------------------------------------------
-    OPENSEA_OPERATIONS_API int print_Capacity_Product_Information(tDevice *device);
+    OPENSEA_OPERATIONS_API void print_Capacity_Model_Number_Mapping(ptrcapacityModelNumberMapping capModelMapping);
 
     //-----------------------------------------------------------------------------
     //

--- a/include/set_max_lba.h
+++ b/include/set_max_lba.h
@@ -55,7 +55,7 @@ extern "C"
 
     //-----------------------------------------------------------------------------
     //
-    //  scsi_Set_Max_LBA( tDevice * device )
+    //  scsi_Set_Max_LBA_2( tDevice * device )
     //
     //! \brief   Sets the maxLBA of the selected device using SCSI methods
     //
@@ -63,16 +63,21 @@ extern "C"
     //!   \param[in]  device file descriptor
     //!   \param[in]  newMaxLBA the new maxLBA you wish to set
     //!   \param[in]  reset if set to 1 (or higher), this will reset to the native max, otherwise it will use the newMaxLBA param to set the maxLBA
+    //!   \param[in]  changeId if set to 1 (or higher), this will change model number if available in AMAC feature set
     //!
     //  Exit:
     //!   \return SUCCESS = good, !SUCCESS something went wrong see error codes
     //
     //-----------------------------------------------------------------------------
+    OPENSEA_OPERATIONS_API int scsi_Set_Max_LBA_2(tDevice *device, uint64_t newMaxLBA, bool reset, bool changeId);
+
+    // deprecated wrapper for scsi_Set_Max_LBA_2
+    // TODO: remove me when next major version bump
     OPENSEA_OPERATIONS_API int scsi_Set_Max_LBA(tDevice *device, uint64_t newMaxLBA, bool reset);
 
     //-----------------------------------------------------------------------------
     //
-    //  ata_Set_Max_LBA( tDevice * device )
+    //  ata_Set_Max_LBA_2( tDevice * device )
     //
     //! \brief   Sets the maxLBA of the selected device using HPA or AMA feature sets
     //
@@ -80,16 +85,21 @@ extern "C"
     //!   \param[in]  device file descriptor
     //!   \param[in]  newMaxLBA the new maxLBA you wish to set
     //!   \param[in]  reset if set to 1 (or higher), this will reset to the native max, otherwise it will use the newMaxLBA param to set the maxLBA
+    //!   \param[in]  changeId if set to 1 (or higher), this will change model number if available in AMAC feature set
     //!
     //  Exit:
     //!   \return SUCCESS = good, !SUCCESS something went wrong see error codes
     //
     //-----------------------------------------------------------------------------
+    OPENSEA_OPERATIONS_API int ata_Set_Max_LBA_2(tDevice *device, uint64_t newMaxLBA, bool reset, bool changeId);
+
+    // deprecated wrapper for ata_Set_Max_LBA_2
+    // TODO: remove me when next major version bump
     OPENSEA_OPERATIONS_API int ata_Set_Max_LBA(tDevice *device, uint64_t newMaxLBA, bool reset);
 
     //-----------------------------------------------------------------------------
     //
-    //  set_Max_LBA( tDevice * device )
+    //  set_Max_LBA_2( tDevice * device )
     //
     //! \brief   Sets the maxLBA of the selected device. This will work with new and old methods.
     //!          If ATA, we have only implemented the legacy method for 48bit drives
@@ -98,11 +108,16 @@ extern "C"
     //!   \param[in]  device file descriptor
     //!   \param[in]  newMaxLBA the new maxLBA you wish to set
     //!   \param[in]  reset if set to 1 (or higher), this will reset to the native max, otherwise it will use the newMaxLBA param to set the maxLBA
+    //!   \param[in]  changeId if set to 1 (or higher), this will change model number if available in AMAC feature set
     //!
     //  Exit:
     //!   \return SUCCESS = good, !SUCCESS something went wrong see error codes
     //
     //-----------------------------------------------------------------------------
+    OPENSEA_OPERATIONS_API int set_Max_LBA_2(tDevice *device, uint64_t newMaxLBA, bool reset, bool changeId);
+
+    // deprecated wrapper for set_Max_LBA_2
+    // TODO: remove me when next major version bump
     OPENSEA_OPERATIONS_API int set_Max_LBA(tDevice *device, uint64_t newMaxLBA, bool reset);
 
 #if defined (__cplusplus)

--- a/src/logs.c
+++ b/src/logs.c
@@ -2475,6 +2475,7 @@ int print_Supported_ATA_Logs(tDevice *device, uint64_t flags)
             case ATA_LOG_CURRENT_DEVICE_INTERNAL_STATUS_DATA_LOG:
             case ATA_LOG_SAVED_DEVICE_INTERNAL_STATUS_DATA_LOG:
             case ATA_LOG_SECTOR_CONFIGURATION_LOG:
+            case ATA_LOG_CAPACITY_MODELNUMBER_MAPPING:
                 if (smartLogSize)
                 {
                     bug = true;

--- a/src/smart.c
+++ b/src/smart.c
@@ -4561,6 +4561,9 @@ static void get_GPL_Log_Command_Info(const char* commandName, uint8_t commandOpC
     case ATA_LOG_IDENTIFY_DEVICE_DATA:
         snprintf(logAddressName, GPL_LOG_NAME_LENGTH, "Identify Device Data");
         break;
+    case ATA_LOG_CAPACITY_MODELNUMBER_MAPPING:
+        snprintf(logAddressName, GPL_LOG_NAME_LENGTH, "Capacity/Model Number Mapping");
+        break;
     case ATA_SCT_COMMAND_STATUS:
         snprintf(logAddressName, GPL_LOG_NAME_LENGTH, "SCT Command/Status");
         break;
@@ -4888,6 +4891,10 @@ static void get_SMART_Log_Info(const char* commandName, M_ATTR_UNUSED uint8_t co
         break;
     case ATA_LOG_IDENTIFY_DEVICE_DATA:
         snprintf(logAddressName, SMART_LOG_ADDRESS_NAME_LENGTH, "Identify Device Data");
+        break;
+    case ATA_LOG_CAPACITY_MODELNUMBER_MAPPING://GPL log...should be an error using this command!
+        snprintf(logAddressName, SMART_LOG_ADDRESS_NAME_LENGTH, "Capacity/Model Number Mapping");
+        invalidLog = true;
         break;
     case ATA_SCT_COMMAND_STATUS:
         snprintf(logAddressName, SMART_LOG_ADDRESS_NAME_LENGTH, "SCT Command/Status");


### PR DESCRIPTION
I spend some time trying to make up this feature. This PR will merge to feature branch so that the work could continue without breaking develop branch.

There are something needs review:

1. The naming for structs and functions may be revised. ACS names the log `Capacity/Model Number Mapping log` while SBC names `Capacity/Product Identification Mapping VPD page`. ACS names the bit `ENABLE CHANGE IDENTIFY STRINGS bit` while SBC names `CAPPID bit`. Personally I don't like the abbreviation of `ID` which may indicate index which looks like an integer. I try to have the names neutral but please correct me if they are not precise.
2. I keep original API `scsi_Set_Max_LBA`, `ata_Set_Max_LBA` and `set_Max_LBA` but create new function with `_2` suffix to keep original API not broken. But it would be better to deprecate old API and bump project major version at a proper time.
3. I follow original work which have the function related to `Capacity/Model Number Mapping log` / `Capacity/Product Identification Mapping VPD page` placed in `drive_info.c` but it may be better placed in `set_max_lba.c`.
4. The original change breaks some indent and I tried to revert them, which leads some "unrelated" changes.