### PR TITLE
quick: fix wrong endian of SCT error recovery min timer

### DIFF
--- a/src/smart.c
+++ b/src/smart.c
@@ -4287,7 +4287,7 @@ eReturnValues sct_Get_Min_Recovery_Time_Limit(tDevice* device, uint32_t* minRcvT
             uint16_t sctFormatVersion = M_BytesTo2ByteValue(sctStatus[1], sctStatus[0]);
             if (sctFormatVersion > 2)
             {
-                *minRcvTimeLmtMilliseconds = M_BytesTo2ByteValue(sctStatus[216], sctStatus[217]);
+                *minRcvTimeLmtMilliseconds = M_BytesTo2ByteValue(sctStatus[217], sctStatus[216]);
                 *minRcvTimeLmtMilliseconds *= 100;
                 ret = SUCCESS;
             }


### PR DESCRIPTION
I checked SCT error recovery min timer of a WD drive:
```
# SeaChest_Configure_linux_x86_64 -d /dev/sda --sctReadTimer info

/dev/sg5 - xxxxxxxxxxxxxxx - xxxxxxxx - xxxxxxxx - ATA
SCT error recovery control timer minimum supported value is 1664000ms
SCT error recovery control read timer is 0ms (volatile)
SCT error recovery control read timer is 0ms (non-volatile)
```
with SCT return status buffer:
```
          0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
  0x0000 03 00 02 01 01 00 00 00 00 00 00 00 00 00 00 00   ................
  0x0010 03 00 04 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x0020 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x0030 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x0040 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x0050 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x0060 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x0070 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x0080 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x0090 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x00A0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x00B0 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00   ................
  0x00C0 00 00 00 00 00 00 00 00 23 F0 24 F0 24 00 00 00   ........#.$.$...
  0x00D0 00 00 55 0E 00 00 00 00 41 00 00 00 00 00 00 00   ..U.....A.......
```
offset 0xd8 contains u16 type SCT error recovery min timer which is `41 00`.
This should be 0x0041 = 6500 ms.