### PR TITLE
quick: add minimal timer to ATA EPC timer output

### DIFF
--- a/src/power_control.c
+++ b/src/power_control.c
@@ -2275,7 +2275,7 @@ eReturnValues get_EPC_Settings(const tDevice* device, ptrEpcSettings epcSettings
     }
 }
 
-static void print_Power_Condition(ptrPowerConditionInfo condition, const char* conditionName, bool showMinTimer)
+static void print_Power_Condition(ptrPowerConditionInfo condition, const char* conditionName)
 {
     printf("%-9s ", conditionName);
     if (condition->currentTimerEnabled)
@@ -2306,17 +2306,8 @@ static void print_Power_Condition(ptrPowerConditionInfo condition, const char* c
     }
     printf("%-10" PRIu32 " ", condition->savedTimerSetting);
     printf("%-13" PRIu32 " ", condition->nominalRecoveryTimeToActiveState);
-    if (showMinTimer)
-    {
-        if (condition->minimumTimerSetting == UINT32_C(0))
-        {
-            print_str("N/A      ");
-        }
-        else
-        {
-            printf("%-8" PRIu32 " ", condition->minimumTimerSetting);
-        }
-    }
+    printf("%-11" PRIu32 " ", condition->minimumTimerSetting);
+    printf("%-10" PRIu32 " ", condition->maximumTimerSetting);
     if (condition->powerConditionChangeable)
     {
         print_str(" Y");
@@ -2350,35 +2341,27 @@ void print_EPC_Settings(const tDevice* device, ptrEpcSettings epcSettings)
     print_str("\tC column = Changeable\n");
     print_str("\tS column = Savable\n");
     print_str("\tAll times are in 100 milliseconds\n\n");
-    if (device->drive_info.drive_type == ATA_DRIVE)
-    {
-        printf("%-9s %-13s %-13s %-11s %-13s %-9s C S\n", "Name", "Current Timer", "Default Timer", "Saved Timer",
-            "Recovery Time", "Min Timer");
-    }
-    else
-    {
-        printf("%-9s %-13s %-13s %-11s %-13s C S\n", "Name", "Current Timer", "Default Timer", "Saved Timer",
-            "Recovery Time");
-    }
+    printf("%-9s %-13s %-13s %-11s %-13s %-11s %-11s C S\n", "Name", "Current Timer", "Default Timer", "Saved Timer",
+        "Recovery Time", "Min Timer", "Max Timer");
     if (epcSettings->idle_a.powerConditionSupported)
     {
-        print_Power_Condition(&epcSettings->idle_a, "Idle A", device->drive_info.drive_type == ATA_DRIVE);
+        print_Power_Condition(&epcSettings->idle_a, "Idle A");
     }
     if (epcSettings->idle_b.powerConditionSupported)
     {
-        print_Power_Condition(&epcSettings->idle_b, "Idle B", device->drive_info.drive_type == ATA_DRIVE);
+        print_Power_Condition(&epcSettings->idle_b, "Idle B");
     }
     if (epcSettings->idle_c.powerConditionSupported)
     {
-        print_Power_Condition(&epcSettings->idle_c, "Idle C", device->drive_info.drive_type == ATA_DRIVE);
+        print_Power_Condition(&epcSettings->idle_c, "Idle C");
     }
     if (epcSettings->standby_y.powerConditionSupported)
     {
-        print_Power_Condition(&epcSettings->standby_y, "Standby Y", device->drive_info.drive_type == ATA_DRIVE);
+        print_Power_Condition(&epcSettings->standby_y, "Standby Y");
     }
     if (epcSettings->standby_z.powerConditionSupported)
     {
-        print_Power_Condition(&epcSettings->standby_z, "Standby Z", device->drive_info.drive_type == ATA_DRIVE);
+        print_Power_Condition(&epcSettings->standby_z, "Standby Z");
     }
     /*if (epcSettings->settingsAffectMultipleLogicalUnits)
     {

--- a/src/power_control.c
+++ b/src/power_control.c
@@ -2275,9 +2275,9 @@ eReturnValues get_EPC_Settings(const tDevice* device, ptrEpcSettings epcSettings
     }
 }
 
-static void print_Power_Condition(ptrPowerConditionInfo condition, const char* conditionName)
+static void print_Power_Condition(ptrPowerConditionInfo condition, const char* conditionName, bool showMinTimer)
 {
-    printf("%-10s ", conditionName);
+    printf("%-9s ", conditionName);
     if (condition->currentTimerEnabled)
     {
         print_str("*");
@@ -2304,8 +2304,19 @@ static void print_Power_Condition(ptrPowerConditionInfo condition, const char* c
     {
         print_str(" ");
     }
-    printf("%-12" PRIu32 " ", condition->savedTimerSetting);
-    printf("%-12" PRIu32 " ", condition->nominalRecoveryTimeToActiveState);
+    printf("%-10" PRIu32 " ", condition->savedTimerSetting);
+    printf("%-13" PRIu32 " ", condition->nominalRecoveryTimeToActiveState);
+    if (showMinTimer)
+    {
+        if (condition->minimumTimerSetting == UINT32_C(0))
+        {
+            print_str("N/A      ");
+        }
+        else
+        {
+            printf("%-8" PRIu32 " ", condition->minimumTimerSetting);
+        }
+    }
     if (condition->powerConditionChangeable)
     {
         print_str(" Y");
@@ -2339,27 +2350,35 @@ void print_EPC_Settings(const tDevice* device, ptrEpcSettings epcSettings)
     print_str("\tC column = Changeable\n");
     print_str("\tS column = Savable\n");
     print_str("\tAll times are in 100 milliseconds\n\n");
-    printf("%-10s %-13s %-13s %-13s %-12s C S\n", "Name", "Current Timer", "Default Timer", "Saved Timer",
-           "Recovery Time");
+    if (device->drive_info.drive_type == ATA_DRIVE)
+    {
+        printf("%-9s %-13s %-13s %-11s %-13s %-9s C S\n", "Name", "Current Timer", "Default Timer", "Saved Timer",
+            "Recovery Time", "Min Timer");
+    }
+    else
+    {
+        printf("%-9s %-13s %-13s %-11s %-13s C S\n", "Name", "Current Timer", "Default Timer", "Saved Timer",
+            "Recovery Time");
+    }
     if (epcSettings->idle_a.powerConditionSupported)
     {
-        print_Power_Condition(&epcSettings->idle_a, "Idle A");
+        print_Power_Condition(&epcSettings->idle_a, "Idle A", device->drive_info.drive_type == ATA_DRIVE);
     }
     if (epcSettings->idle_b.powerConditionSupported)
     {
-        print_Power_Condition(&epcSettings->idle_b, "Idle B");
+        print_Power_Condition(&epcSettings->idle_b, "Idle B", device->drive_info.drive_type == ATA_DRIVE);
     }
     if (epcSettings->idle_c.powerConditionSupported)
     {
-        print_Power_Condition(&epcSettings->idle_c, "Idle C");
+        print_Power_Condition(&epcSettings->idle_c, "Idle C", device->drive_info.drive_type == ATA_DRIVE);
     }
     if (epcSettings->standby_y.powerConditionSupported)
     {
-        print_Power_Condition(&epcSettings->standby_y, "Standby Y");
+        print_Power_Condition(&epcSettings->standby_y, "Standby Y", device->drive_info.drive_type == ATA_DRIVE);
     }
     if (epcSettings->standby_z.powerConditionSupported)
     {
-        print_Power_Condition(&epcSettings->standby_z, "Standby Z");
+        print_Power_Condition(&epcSettings->standby_z, "Standby Z", device->drive_info.drive_type == ATA_DRIVE);
     }
     /*if (epcSettings->settingsAffectMultipleLogicalUnits)
     {


### PR DESCRIPTION
SATA drives support minimal timer field in EPC log, which points out lower limit for available timer input.

This value is already read from drive but not shown in `--showEPCSettings` output.

Currently Toshiba products support this field and Seagate may support in future.

I also do some modification to output so that it could displays in 80 characters width in terminal.

Before:

```
Name       Current Timer Default Timer Saved Timer   Recovery Time C S
Idle A      0            *20           *20           1             Y Y
Idle B      0            *9000         *9000         12            Y Y
Idle C      0             18000         18000        50            Y Y
Standby Y   0             4294967295    4294967295   50            Y Y
Standby Z   0             4294967295    4294967295   250           Y Y
```
After:
```
Name      Current Timer Default Timer Saved Timer Recovery Time Min Timer C S
Idle A     0            *20           *20         1             1         Y Y
Idle B     0            *9000         *9000       12            10        Y Y
Idle C     0             18000         18000      50            50        Y Y
Standby Y  0             4294967295    4294967295 50            50        Y Y
Standby Z  0             4294967295    4294967295 250           50        Y Y
```