### PR TITLE
2 fixes to FARM and SMART Error log printing

### DIFF
--- a/src/farm_log.c
+++ b/src/farm_log.c
@@ -3083,12 +3083,10 @@ static void print_Farm_Drive_Info(farmDriveInfo* driveInfo, eFARMDriveInterface*
                                                      driveInfo->maxAvailableSectorsForReassignment);
             print_Stat_If_Supported_And_Valid_Bool("HAMR Data Protect Status", driveInfo->hamrDataProtectStatus,
                                                    "Data Protect", "No Data Protect");
-            print_Stat_If_Supported_And_Valid_Time("POH of Most Recent FARM TS Frame",
-                                                   driveInfo->pohOfMostRecentTimeseriesFrame,
-                                                   MICRO_SECONDS_PER_MILLI_SECONDS);
-            print_Stat_If_Supported_And_Valid_Time("POH of 2nd Most Recent FARM TS Frame",
-                                                   driveInfo->pohOfSecondMostRecentTimeseriesFrame,
-                                                   MICRO_SECONDS_PER_MILLI_SECONDS);
+            print_Stat_If_Supported_And_Valid_Uint64("POH of Most Recent FARM TS Frame",
+                                                   driveInfo->pohOfMostRecentTimeseriesFrame);
+            print_Stat_If_Supported_And_Valid_Uint64("POH of 2nd Most Recent FARM TS Frame",
+                                                   driveInfo->pohOfSecondMostRecentTimeseriesFrame);
             print_Stat_If_Supported_And_Valid_Uint64(
                 "Seq or Before Req for Active Zone Config",
                 driveInfo->sequentialOrBeforeWriteRequiredForActiveZoneConfiguration);

--- a/src/smart.c
+++ b/src/smart.c
@@ -11639,7 +11639,7 @@ static void get_Error_Info(uint8_t                commandOpCodeThatCausedError,
         // Parse error field bits
         if (error & ATA_ERROR_BIT_ABORT)
         {
-            safe_strcat(statusMessage, ATA_STATUS_MESSAGE_MAX_LENGTH, "Abort");
+            safe_strcat(errorMessage, ATA_ERROR_MESSAGE_MAX_LENGTH, "Abort");
         }
         if (error & ATA_ERROR_BIT_INTERFACE_CRC) // abort bit will also be set to 1 if this is set to 1
         {
@@ -11685,27 +11685,13 @@ static void get_Error_Info(uint8_t                commandOpCodeThatCausedError,
         {
             if (is_Possible_Recalibrate_Command(commandOpCodeThatCausedError))
             {
-                if (safe_strlen(errorMessage) > 0)
-                {
-                    safe_strcat(errorMessage, ATA_ERROR_MESSAGE_MAX_LENGTH, ", ");
-                }
-                safe_strcat(errorMessage, ATA_ERROR_MESSAGE_MAX_LENGTH, "(Likely) Track Zero Not Found");
+                snprintf_err_handle(errorMessage, ATA_ERROR_MESSAGE_MAX_LENGTH, "(Likely) Track Zero Not Found");
             }
             else
             {
-                if (safe_strlen(errorMessage) > 0)
-                {
-                    safe_strcat(errorMessage, ATA_ERROR_MESSAGE_MAX_LENGTH, ", ");
-                }
                 // unknown error, possibly recalibrate command + track zero not found....
-                char*   dup    = M_NULLPTR;
-                errno_t duperr = safe_strdup(&dup, errorMessage);
-                if (duperr == 0 && dup != M_NULLPTR)
-                {
-                    snprintf_err_handle(errorMessage, ATA_ERROR_MESSAGE_MAX_LENGTH,
-                                        "%sUnknown Error Condition (%02" PRIX8 "h)", dup, error);
-                    safe_free(&dup);
-                }
+                snprintf_err_handle(errorMessage, ATA_ERROR_MESSAGE_MAX_LENGTH,
+                                    "Unknown Error Condition (%02" PRIX8 "h)", error);
             }
         }
     }


### PR DESCRIPTION
I find 2x issues:

The 1st is with FARM printing. The unit of recent frames are actually hours. Original code parse them as milliseconds causing output being always 0.

The 2nd is with `openSeaChest_SMART -d /dev/sdX --showSMARTErrorLog summary`. Originally it shows:
```
==========================================================================================

/dev/sg10 - ST36000NM001M-3UV133 - K3101WT0 - ZZZZ - ATA
SMART Summary Error Log- Version 1:
        Found 5 errors! Total Error Count: 33

===============================================
Error 1 - Drive State: Active/Idle Life Timestamp:  134 days 4 hours
1 - 9D:1H:49M:25S:507MS - Read Log Ext DMA - Log: SCT Command/Status Page Number: 0 PageCount: 1 Features: 0h
2 - 9D:1H:49M:25S:516MS - Read Log Ext DMA - Log: Vendor Specific (A6h) Page Number: 0 PageCount: 32 Features: 0h
3 - 9D:1H:49M:25S:559MS - Read Log Ext DMA - Log: Vendor Specific (A6h) Page Number: 32 PageCount: 32 Features: 0h
4 - 9D:1H:49M:25S:609MS - SMART - Read SMART Data, SMART Signature Valid
5 - 9D:1H:49M:25S:610MS - Write Log Ext DMA - Log: SCT Command/Status Page Number: 0 PageCount: 1 Features: 0h
abort_handler_s: safe_strdup: src is len 0
Error code: 22
        Additional Error info:
                File:       smart.c
                Line:       9057
                Function:   get_Error_Info
                Expression: safe_strdup(&dup, errorMessage)
Aborted (core dumped)
```
The error is introduced in commit https://github.com/Seagate/opensea-operations/commit/ed2ad19d472d6df5f94fd7ff1962ae95878a436a. However, there are two problems here:

1. lines after line 11684 of `src/smart.c` are over-generalized. In original source code, line 11684 assumes array `errorMessage` is 0 length. But line 11688 and 11606 start to consider non-empty `errorMessage`. Furthermore, line 11072 uses function `safe_strdup` which requires non-empty `errorMessage`. I removed all unnecessary handling because `errorMessage` is promised to be 0 length in the beginning.
2. Starting from line 11631 of `src/smart.c`, the logic here is that, we've found variable `status` indicates "Error Reg Valid", then we should turn to variable `error` (error field) for detail. And in this case parse result of variable `error` should be stored in variable `errorMessage` but not `statusMessage`.
With two fixes, output is corrected to:
```
/dev/sg10 - ST36000NM001M-3UV133 - K3101WT0 - ZZZZ - ATA
SMART Summary Error Log- Version 1:
        Found 5 errors! Total Error Count: 33

===============================================
Error 1 - Drive State: Active/Idle Life Timestamp:  134 days 4 hours
1 - 9D:1H:49M:25S:507MS - Read Log Ext DMA - Log: SCT Command/Status Page Number: 0 PageCount: 1 Features: 0h
2 - 9D:1H:49M:25S:516MS - Read Log Ext DMA - Log: Vendor Specific (A6h) Page Number: 0 PageCount: 32 Features: 0h
3 - 9D:1H:49M:25S:559MS - Read Log Ext DMA - Log: Vendor Specific (A6h) Page Number: 32 PageCount: 32 Features: 0h
4 - 9D:1H:49M:25S:609MS - SMART - Read SMART Data, SMART Signature Valid
5 - 9D:1H:49M:25S:610MS - Write Log Ext DMA - Log: SCT Command/Status Page Number: 0 PageCount: 1 Features: 0h
Error: Status: Error Reg Valid  Error: Abort    LBA: 000000270000h      Device: 40
```