### PR TITLE
bug: Prevent the OS from turning the USB link off during DST

### DIFF
--- a/src/dst.c
+++ b/src/dst.c
@@ -83,7 +83,7 @@ OPENSEA_OPERATIONS_API eReturnValues ata_Get_DST_Progress(const tDevice* M_NONNU
     eReturnValues result = SUCCESS;
     DECLARE_ZERO_INIT_ARRAY(uint8_t, temp_buf, ATA_SMART_READ_DATA_SIZE);
     result = ata_SMART_Read_Data(device, temp_buf, sizeof(temp_buf));
-    if (result == SUCCESS)
+    if (result == SUCCESS || result == WARN_INVALID_CHECKSUM)
     {
         // get the progress
         *percentComplete = ATA_SELF_TEST_PROGRESS_SCSI_CONVERSION_FACTOR -
@@ -1059,6 +1059,9 @@ static eReturnValues poll_DST_Progress(const tDevice* M_NONNULL device,
     const char* overTimeWarningMessage = "WARNING: DST is taking longer than expected.";
     bool        showTimeWarning        = false;
     bool        abortForTooLong        = false;
+
+    os_Disable_Idle_Power(device);
+
     while (status == 0x0F && (ret == SUCCESS || ret == IN_PROGRESS))
     {
         lastProgressIndication = percentComplete;
@@ -1114,6 +1117,9 @@ static eReturnValues poll_DST_Progress(const tDevice* M_NONNULL device,
         }
         delay_Seconds(timing.pollingInterval);
     }
+
+    os_Restore_Idle_Power(device);
+
     if (status == 0 && ret == SUCCESS)
     {
         if (showProgress)


### PR DESCRIPTION
We observed that Windows may turn the USB link off or into some low power mode when it seems inactive during DST. This creates a problem when it comes to polling though as not all devices wake up nicely or quickly. It can create a command timeout or cause a USB reset to be issued, which becomes a ATA reset which stops DST. This addition temporarily disables this power saving mode, then restores it again once DST has completed.